### PR TITLE
Fix encryption support

### DIFF
--- a/app/lib/client/client.dart
+++ b/app/lib/client/client.dart
@@ -128,11 +128,11 @@ class SPHclient {
           await dio.get(location2);
           
           if (userLogin) {
-            int encryptionStatusName = await startLanisEncryption();
-            debugPrint("Encryption connected with status code: $encryptionStatusName");
-
             await fetchRedundantData();
           }
+
+          int encryptionStatusName = await startLanisEncryption();
+          debugPrint("Encryption connected with status code: $encryptionStatusName");
 
           return 0;
         } else {


### PR DESCRIPTION
Sollte jetzt "funktionieren". Hat eigentlich schon immer funktioniert, man musste nur mit UTF8 kodieren nicht BASE64, ja super.

+ funktionierendes decryptString hinzugefügt.
+ Login Verschlüsselungs fix von @alessioC42 vom `mein_unterricht` branch.
+ decrypt() und decryptString() kann auch `null` returnen.