### PR TITLE
Support für "Nachrichten Beta-Version" hinzufügen

### DIFF
--- a/app/lib/client/client.dart
+++ b/app/lib/client/client.dart
@@ -439,6 +439,42 @@ class SPHclient {
     debugPrint(result.toString());
   }
 
+  Future<dynamic> getConversationsOverview() async {
+    try {
+      final response =
+      await dio.post("https://start.schulportal.hessen.de/nachrichten.php",
+          data: {"a": "headers", "getType": "visibleOnly", "last": "0"},
+          options: Options(
+            headers: {
+              "Accept": "*/*",
+              "Content-Type":
+              "application/x-www-form-urlencoded; charset=UTF-8",
+              "Sec-Fetch-Dest": "empty",
+              "Sec-Fetch-Mode": "cors",
+              "Sec-Fetch-Site": "same-origin",
+              "X-Requested-With": "XMLHttpRequest",
+            },
+          ));
+
+      final Map<String, dynamic> encryptedJSON = jsonDecode(response.toString());
+
+      final String? decryptedConversations = cryptor.decryptString(encryptedJSON["rows"]);
+
+      if (decryptedConversations == null) {
+        return -4;
+        // unknown error (encrypted isn't salted)
+      }
+
+      return jsonDecode(decryptedConversations);
+    } on (SocketException, DioException) {
+      return -3;
+      // network error
+    } catch (e) {
+      return -4;
+      // unknown error
+    }
+  }
+
   Future<int> startLanisEncryption() async {
     return await cryptor.start();
   }

--- a/app/lib/client/client.dart
+++ b/app/lib/client/client.dart
@@ -440,11 +440,11 @@ class SPHclient {
     debugPrint(result.toString());
   }
 
-  Future<dynamic> getConversationsOverview() async {
+  Future<dynamic> getConversationsOverview(bool invisible) async {
     try {
       final response =
       await dio.post("https://start.schulportal.hessen.de/nachrichten.php",
-          data: {"a": "headers", "getType": "visibleOnly", "last": "0"},
+          data: {"a": "headers", "getType": invisible ? "unvisibleOnly" : "visibleOnly", "last": "0"},
           options: Options(
             headers: {
               "Accept": "*/*",

--- a/app/lib/client/client.dart
+++ b/app/lib/client/client.dart
@@ -479,7 +479,6 @@ class SPHclient {
   Future<dynamic> getSingleConversation(String uniqueID) async {
     try {
       final encryptedUniqueID = cryptor.encryptString(uniqueID);
-      print("encrypted: $encryptedUniqueID");
 
       final response =
       await dio.post("https://start.schulportal.hessen.de/nachrichten.php",

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:sph_plan/client/client.dart';
 import 'package:sph_plan/view/calendar/calendar.dart';
+import 'package:sph_plan/view/conversations/conversations.dart';
 import 'package:sph_plan/view/settings/settings.dart';
 import 'package:sph_plan/view/settings/subsettings/user_login.dart';
 import 'package:sph_plan/view/vertretungsplan/vertretungsplan.dart';
@@ -147,6 +148,7 @@ class _HomePageState extends State<HomePage> {
     return <Widget>[
       const VertretungsplanAnsicht(),
       const CalendarAnsicht(),
+      const ConversationsAnsicht(),
     ];
   }
 
@@ -237,6 +239,17 @@ class _HomePageState extends State<HomePage> {
                   Navigator.pop(context);
                 },
               )
+            ),
+            Visibility(
+                visible: client.doesSupportFeature("Nachrichten - Beta-Version"),
+                child: ListTile(
+                  title: const Text('Nachrichten'),
+                  selected: _selectedIndex == 2,
+                  onTap: () {
+                    _onItemTapped(2, "Nachrichten");
+                    Navigator.pop(context);
+                  },
+                )
             ),
             ListTile(
               title: const Text('Schulportal öffnen'),

--- a/app/lib/view/conversations/conversations.dart
+++ b/app/lib/view/conversations/conversations.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+
+import '../../client/client.dart';
+
+class ConversationsAnsicht extends StatefulWidget {
+  const ConversationsAnsicht({Key? key}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => _ConversationsAnsichtState();
+}
+
+class _ConversationsAnsichtState extends State<ConversationsAnsicht> {
+  double padding = 10.0;
+
+  final CardInfo lastCard = CardInfo(
+      title: const Text("Keine weiteren Einträge!", style: TextStyle(fontSize: 21)),
+      body: const Text("Alle Angaben ohne Gewähr. \nDie Funktionalität der App hängt stark von der verwendeten Schule und den eingestellten Filtern ab."),
+      footer: const Text("")
+  );
+
+  void showSnackbar(String text, {seconds = 1, milliseconds = 0}) {
+    if (mounted) {
+      // Hide the current SnackBar if one is already visible.
+      ScaffoldMessenger.of(context).hideCurrentSnackBar();
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(text),
+          duration: Duration(seconds: seconds, milliseconds: milliseconds),
+        ),
+      );
+    }
+  }
+
+  Future<List<CardInfo>?> getConversationOverview() async {
+    final conversations = await client
+        .getConversationsOverview();
+    if (conversations is int) {
+      showSnackbar(client.statusCodes[conversations] ?? "Unbekannter Fehler");
+      return null;
+      // TODO: ADD SECOND TRY
+    } else {
+      // TODO: ADD FILTER
+
+      List<CardInfo> cards = [];
+
+      for (final conversation in conversations) {
+        cards.add(
+            CardInfo(
+                title: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Flexible(
+                      flex: 3,
+                      child: Text(
+                        conversation["Betreff"] ?? "",
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(fontSize: 21),
+                      ),
+                    ),
+                    Flexible(
+                      child: Text(
+                        conversation["kuerzel"] ?? "",
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(fontSize: 17),
+                      ),
+                    ),
+                  ],
+                ),
+                footer: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      conversation["Datum"] ?? "", // TODO: maybe convert the date later
+                    )
+                  ],
+                )
+            )
+        );
+      }
+
+      cards.add(lastCard);
+
+      return cards;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: FutureBuilder(
+        future: getConversationOverview(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.waiting) {
+            // Error content
+            if (snapshot.data == null) {
+              return const Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(Icons.warning, size: 60,),
+                      Padding(
+                        padding: EdgeInsets.all(50),
+                        child: Text(
+                            "Es gibt wohl ein Problem, bitte kontaktiere den Entwickler der App!",
+                            textAlign: TextAlign.center,
+                            style: TextStyle(fontSize: 22)
+                        ),
+                      ),
+                    ],
+                  )
+              );
+            }
+            // Content
+            return ListView.builder(
+              itemCount: snapshot.data!.length,
+                itemBuilder: (context, index) {
+                  return Padding(
+                    padding:
+                    EdgeInsets.only(left: padding, right: padding, bottom: padding),
+                    child: Card(
+                      child: InkWell(
+                        onTap: () {
+                          showSnackbar("Lanis hat Gnade mit dir.");
+                        },
+                        customBorder: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                        child: ListTile(
+                          title: snapshot.data![index].title,
+                          subtitle: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              if (snapshot.data![index].body != null) ...[snapshot.data![index].body!],
+                              snapshot.data![index].footer,
+                            ],
+                          ),
+                        ),
+                      )
+                    ),
+                  );
+                }
+            );
+          }
+          // Waiting content
+          return const Scaffold(
+            body: Center(
+              child: CircularProgressIndicator(),
+            )
+          );
+        },
+      ),
+    );
+  }
+}
+
+// Borrowed from vertretungsplan.dart
+class CardInfo {
+  final Widget title;
+  final Widget footer;
+  final Widget? body;
+
+  CardInfo({
+    required this.title,
+    required this.footer,
+    this.body
+  });
+}

--- a/app/lib/view/conversations/detailed_conversation.dart
+++ b/app/lib/view/conversations/detailed_conversation.dart
@@ -1,17 +1,21 @@
 import 'package:flutter/material.dart';
-
+import 'package:html/parser.dart';
 import '../../client/client.dart';
 
 class DetailedConversationAnsicht extends StatefulWidget {
   final String uniqueID;
   final String? title;
-  const DetailedConversationAnsicht({super.key, required this.uniqueID, required this.title});
+
+  const DetailedConversationAnsicht(
+      {super.key, required this.uniqueID, required this.title});
 
   @override
-  State<DetailedConversationAnsicht> createState() => _DetailedConversationAnsichtState();
+  State<DetailedConversationAnsicht> createState() =>
+      _DetailedConversationAnsichtState();
 }
 
-class _DetailedConversationAnsichtState extends State<DetailedConversationAnsicht> {
+class _DetailedConversationAnsichtState
+    extends State<DetailedConversationAnsicht> {
   late final Future<dynamic> _getSingleConversation;
 
   @override
@@ -20,26 +24,164 @@ class _DetailedConversationAnsichtState extends State<DetailedConversationAnsich
     _getSingleConversation = client.getSingleConversation(widget.uniqueID);
   }
 
+  Widget getConversationWidget(
+      Map<String, dynamic> conversation, bool rootMessage) {
+    final contentParser = parse(conversation["Inhalt"]);
+    final content = contentParser.body!.text;
+
+    return Padding(
+      padding: const EdgeInsets.only(left: 12.0, right: 12.0),
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(bottom: 4.0, top: 8.0),
+            child: Row(
+              children: [
+                const Padding(
+                  padding: EdgeInsets.only(right: 4.0),
+                  child: Icon(
+                    Icons.person,
+                    size: 18,
+                  ),
+                ),
+                Text(
+                  conversation["username"],
+                  style: Theme.of(context).textTheme.labelSmall,
+                )
+              ],
+            ),
+          ),
+          // Do not show title again in a comment.
+          if (rootMessage) ...[
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4.0),
+              child: Row(
+                children: [
+                  Flexible(
+                    flex: 10,
+                    child: Text(
+                      conversation["Betreff"],
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+          Padding(
+            padding: const EdgeInsets.only(bottom: 4.0),
+            child: Row(
+              children: [
+                Flexible(
+                  flex: 10,
+                  child: Text(
+                    content,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                )
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8.0),
+            child: Row(
+              children: [
+                Text(
+                  conversation["Datum"],
+                  style: Theme.of(context).textTheme.labelSmall,
+                ),
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(
-          widget.title ?? "Nachricht"
-        ),
+        title: Text(widget.title ?? "Nachricht"),
       ),
       body: FutureBuilder(
           future: _getSingleConversation,
           builder: (context, snapshot) {
             if (snapshot.connectionState != ConnectionState.waiting) {
-              print(snapshot.data);
-              return Placeholder();
+              // Error content
+              if (snapshot.data is int) {
+                return Center(
+                    child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(
+                      Icons.warning,
+                      size: 60,
+                    ),
+                    const Padding(
+                      padding: EdgeInsets.all(50),
+                      child: Text(
+                          "Es gibt wohl ein Problem, bitte kontaktiere den Entwickler der App!",
+                          textAlign: TextAlign.center,
+                          style: TextStyle(fontSize: 22)),
+                    ),
+                    Text(
+                        "Problem: ${client.statusCodes[snapshot.data] ?? "Unbekannter Fehler"}")
+                  ],
+                ));
+              }
+              // Successful content
+              return ListView.builder(
+                  itemCount: snapshot.data["reply"].length + 1,
+                  itemBuilder: (context, index) {
+                    return Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        // Shows on the first comment a "reply" icon.
+                        if (index == 1) ...[
+                          Flexible(
+                            flex: 1,
+                            child: Padding(
+                              padding: const EdgeInsets.only(top: 14.0),
+                              child: RotatedBox(
+                                quarterTurns: 1,
+                                child: Transform.flip(
+                                    flipY: true,
+                                    child: const Icon(Icons.reply)),
+                              ),
+                            ),
+                          ),
+                        ],
+                        // Make a empty box to align it with the first comment.
+                        if (index >= 2) ...[
+                          const Flexible(
+                            flex: 1,
+                            child: SizedBox.shrink(),
+                          )
+                        ],
+                        Flexible(
+                          flex: 10,
+                          child: Padding(
+                              padding: const EdgeInsets.only(
+                                  left: 10.0, right: 10.0, bottom: 10.0),
+                              child: Card(
+                                  // Get root conversation widget or comments.
+                                  child: getConversationWidget(
+                                      index == 0
+                                          ? snapshot.data
+                                          : snapshot.data["reply"][index - 1],
+                                      index == 0 ? true : false))),
+                        ),
+                      ],
+                    );
+                  });
             }
+            // Waiting content
             return const Center(
               child: CircularProgressIndicator(),
             );
-          }
-      ),
+          }),
     );
   }
 }

--- a/app/lib/view/conversations/detailed_conversation.dart
+++ b/app/lib/view/conversations/detailed_conversation.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+import '../../client/client.dart';
+
+class DetailedConversationAnsicht extends StatefulWidget {
+  final String uniqueID;
+  final String? title;
+  const DetailedConversationAnsicht({super.key, required this.uniqueID, required this.title});
+
+  @override
+  State<DetailedConversationAnsicht> createState() => _DetailedConversationAnsichtState();
+}
+
+class _DetailedConversationAnsichtState extends State<DetailedConversationAnsicht> {
+  late final Future<dynamic> _getSingleConversation;
+
+  @override
+  void initState() {
+    super.initState();
+    _getSingleConversation = client.getSingleConversation(widget.uniqueID);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          widget.title ?? "Nachricht"
+        ),
+      ),
+      body: FutureBuilder(
+          future: _getSingleConversation,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState != ConnectionState.waiting) {
+              print(snapshot.data);
+              return Placeholder();
+            }
+            return const Center(
+              child: CircularProgressIndicator(),
+            );
+          }
+      ),
+    );
+  }
+}

--- a/app/lib/view/settings/subsettings/supported_features.dart
+++ b/app/lib/view/settings/subsettings/supported_features.dart
@@ -11,9 +11,10 @@ class SupportedFeaturesOverviewScreen extends StatefulWidget {
 
 
 final List<String> supportedApps = [
+  "Nachrichten - Beta-Version",
   "Vertretungsplan",
   "Kalender",
-  "Logout"
+  "Logout",
 ];
 
 

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -214,6 +214,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.1"
+  flutter_linkify:
+    dependency: "direct main"
+    description:
+      name: flutter_linkify
+      sha256: "74669e06a8f358fee4512b4320c0b80e51cffc496607931de68d28f099254073"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -368,6 +376,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
+  linkify:
+    dependency: transitive
+    description:
+      name: linkify
+      sha256: "4139ea77f4651ab9c315b577da2dd108d9aa0bd84b5d03d33323f1970c645832"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   lints:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   package_info_plus: ^4.2.0
   encrypt: ^5.0.3
   pointycastle: ^3.7.3
+  flutter_linkify: ^6.0.0
 
 
 flutter_launcher_icons:


### PR DESCRIPTION
**Erst ready zu mergen, wenn die Punkte fertig sind:**

- [x] Nachrichten Überblick Seite
![WhatsApp Image 2023-12-03 at 00 33 47_10b6eada](https://github.com/alessioC42/SPH-vertretungsplan/assets/73837560/95ed9e8c-ba2d-4bdd-8ba9-629bfd51eb2b)
*Aktuelles Layout*
![Screenshot from 2023-12-05 18-03-18](https://github.com/alessioC42/SPH-vertretungsplan/assets/73837560/3a296431-4e60-41aa-99a6-56eeb60e05e5)
*Man kann eingeblendete und ausgeblendete Unterhaltungen sehen.*
![Screenshot from 2023-12-05 17-25-44](https://github.com/alessioC42/SPH-vertretungsplan/assets/73837560/da073deb-7a6c-4d06-8937-9da121f92571)
*Ungelesene Unterhaltung*
![image](https://github.com/alessioC42/SPH-vertretungsplan/assets/73837560/b2623dea-69c8-4fda-9fff-5dfc97d6710f)
*Error Page*
- [x] Nachrichten Details Seite
![Screenshot from 2023-12-03 19-01-30](https://github.com/alessioC42/SPH-vertretungsplan/assets/73837560/772d1394-d965-4f51-8244-cad247df05c0)
- [x] Daten verschlüsseln
- [x] Kommentare zur Details Seite hinzufügen
![comments](https://github.com/alessioC42/SPH-vertretungsplan/assets/73837560/87fc0d9c-11c4-4bdd-85c9-ffd180c07a60)
*Finales Layout*
- [x] Links klickbar machen in der Details Seite
![image](https://github.com/alessioC42/SPH-vertretungsplan/assets/73837560/a475049c-08d9-4513-8f83-b1f5608443cf)
*Klickbarer Link (und Email) mit flutter_linkify*
- [x] Bug fixen, wenn Lehrername warum auch immer in HTML ist.
![Screenshot from 2023-12-04 19-05-49](https://github.com/alessioC42/SPH-vertretungsplan/assets/73837560/254a632b-67e1-46fd-8251-f0d697d61be7)
*Bug*
![image](https://github.com/alessioC42/SPH-vertretungsplan/assets/73837560/f6d90904-daad-45ff-aa3f-2ee9dd04344a)
*Manchmal haben Nachrichten keinen Benutzernamen (Sie werden nur als " , " angezeigt).*

Neue Nachrichten zu erstellen und so würde ich auf ein anderen Pull Request verschieben.
Das gleiche mit Push Benachrichtigungen und filter.