### PR TITLE
Bottom navbar

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -264,6 +264,38 @@ class _HomePageState extends State<HomePage> {
             body: Center(
               child: featureScreens()[selectedFeature.index],
             ),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: selectedFeature.index,
+        onDestinationSelected: (index) => openFeature(Feature.values[index]),
+        destinations: [
+          NavigationDestination(
+            enabled: client.doesSupportFeature("Vertretungsplan"),
+            icon: const Icon(Icons.group),
+            selectedIcon: const Icon(Icons.group_outlined),
+            label: 'Vertretungsplan',
+          ),
+          NavigationDestination(
+            enabled: client.doesSupportFeature("Kalender"),
+            icon: const Icon(Icons.calendar_today),
+            selectedIcon: const Icon(Icons.calendar_today_outlined),
+            label: 'Kalender',
+          ),
+          NavigationDestination(
+            enabled:
+                  client.doesSupportFeature("Nachrichten - Beta-Version"),
+            icon: const Icon(Icons.forum),
+            selectedIcon: const Icon(Icons.forum_outlined),
+            label: 'Nachrichten',
+          ),
+          NavigationDestination(
+            enabled: client.doesSupportFeature("Mein Unterricht") ||
+                client.doesSupportFeature("mein Unterricht"),
+            icon: const Icon(Icons.school),
+            selectedIcon: const Icon(Icons.school_outlined),
+            label: 'Mein Unterricht',
+          ),
+        ],
+      ),
             drawer: NavigationDrawer(
               onDestinationSelected: onNavigationItemTapped,
               selectedIndex: selectedFeature.index,

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -121,6 +121,7 @@ class _HomePageState extends State<HomePage> {
   // For status messages
   late final StreamController statusController;
   late int errorCode;
+  List<int?> bottomNavbarNavigationTranslation = [];
 
   static List<Widget> featureScreens() {
     return <Widget>[
@@ -138,6 +139,22 @@ class _HomePageState extends State<HomePage> {
       performLogin();
     });
 
+    int helpIndex = 0;
+    for (var supported in [
+      client.doesSupportFeature("Vertretungsplan"),
+      client.doesSupportFeature("Kalender"),
+      client.doesSupportFeature("Nachrichten - Beta-Version"),
+      client.doesSupportFeature("Mein Unterricht") ||
+          client.doesSupportFeature("mein Unterricht")
+    ]) {
+      if (supported) {
+        bottomNavbarNavigationTranslation.add(helpIndex);
+        helpIndex += 1;
+      } else {
+        bottomNavbarNavigationTranslation.add(null);
+      }
+    }
+
     super.initState();
   }
 
@@ -151,7 +168,7 @@ class _HomePageState extends State<HomePage> {
     int loginCode = await client.login();
 
     statusController.add(Status.finalize);
-    if (loginCode == -1  || loginCode == -2) {
+    if (loginCode == -1 || loginCode == -2) {
       selectedFeature = Feature.substitutions;
 
       openLoginScreen();
@@ -168,7 +185,6 @@ class _HomePageState extends State<HomePage> {
       });
     }
   }
-
 
   void openLoginScreen() {
     Navigator.push(
@@ -251,51 +267,53 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
-    final Color imageColor = Theme.of(context).colorScheme.inversePrimary.withOpacity(0.5);
-    final Color textColor = imageColor.computeLuminance() < 0.5 ? Colors.white : Colors.black;
+    final Color imageColor =
+        Theme.of(context).colorScheme.inversePrimary.withOpacity(0.5);
+    final Color textColor =
+        imageColor.computeLuminance() < 0.5 ? Colors.white : Colors.black;
 
     return isLoading
         ? loadingScreen()
         : Scaffold(
             appBar: AppBar(
-              title: Text(selectedFeature
-                  .value!), // We could also use a list with all title names, but a empty title should be always the first page (Vp)
+              title: Text(selectedFeature.value!),
             ),
             body: Center(
               child: featureScreens()[selectedFeature.index],
             ),
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: selectedFeature.index,
-        onDestinationSelected: (index) => openFeature(Feature.values[index]),
-        destinations: [
-          NavigationDestination(
-            enabled: client.doesSupportFeature("Vertretungsplan"),
-            icon: const Icon(Icons.group),
-            selectedIcon: const Icon(Icons.group_outlined),
-            label: 'Vertretungsplan',
-          ),
-          NavigationDestination(
-            enabled: client.doesSupportFeature("Kalender"),
-            icon: const Icon(Icons.calendar_today),
-            selectedIcon: const Icon(Icons.calendar_today_outlined),
-            label: 'Kalender',
-          ),
-          NavigationDestination(
-            enabled:
-                  client.doesSupportFeature("Nachrichten - Beta-Version"),
-            icon: const Icon(Icons.forum),
-            selectedIcon: const Icon(Icons.forum_outlined),
-            label: 'Nachrichten',
-          ),
-          NavigationDestination(
-            enabled: client.doesSupportFeature("Mein Unterricht") ||
-                client.doesSupportFeature("mein Unterricht"),
-            icon: const Icon(Icons.school),
-            selectedIcon: const Icon(Icons.school_outlined),
-            label: 'Mein Unterricht',
-          ),
-        ],
-      ),
+            bottomNavigationBar: NavigationBar(
+              selectedIndex:
+                  bottomNavbarNavigationTranslation[selectedFeature.index]!,
+              onDestinationSelected: (index) => openFeature(Feature
+                  .values[bottomNavbarNavigationTranslation.indexOf(index)]),
+              destinations: [
+                if (client.doesSupportFeature("Vertretungsplan"))
+                  const NavigationDestination(
+                    icon: Icon(Icons.group),
+                    selectedIcon: Icon(Icons.group_outlined),
+                    label: 'Vertretungsplan',
+                  ),
+                if (client.doesSupportFeature("Kalender"))
+                  const NavigationDestination(
+                    icon: Icon(Icons.calendar_today),
+                    selectedIcon: Icon(Icons.calendar_today_outlined),
+                    label: 'Kalender',
+                  ),
+                if (client.doesSupportFeature("Nachrichten - Beta-Version"))
+                  const NavigationDestination(
+                    icon: Icon(Icons.forum),
+                    selectedIcon: Icon(Icons.forum_outlined),
+                    label: 'Nachrichten',
+                  ),
+                if (client.doesSupportFeature("Mein Unterricht") ||
+                    client.doesSupportFeature("mein Unterricht"))
+                  const NavigationDestination(
+                    icon: Icon(Icons.school),
+                    selectedIcon: Icon(Icons.school_outlined),
+                    label: 'Mein Unterricht',
+                  ),
+              ],
+            ),
             drawer: NavigationDrawer(
               onDestinationSelected: onNavigationItemTapped,
               selectedIndex: selectedFeature.index,
@@ -309,7 +327,8 @@ class _HomePageState extends State<HomePage> {
                         child: ImageFiltered(
                           imageFilter: ImageFilter.blur(sigmaX: 4, sigmaY: 4),
                           child: ColorFiltered(
-                            colorFilter: ColorFilter.mode(imageColor, BlendMode.srcOver),
+                            colorFilter:
+                                ColorFilter.mode(imageColor, BlendMode.srcOver),
                             child: AspectRatio(
                               aspectRatio: 16 / 9,
                               child: Image.file(
@@ -327,16 +346,19 @@ class _HomePageState extends State<HomePage> {
                           children: [
                             Text(
                               schoolName,
-                              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                color: textColor
-                              ),
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .titleMedium
+                                  ?.copyWith(color: textColor),
                             ),
                             Text(
                               userName,
-                              style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                                fontWeight: FontWeight.bold,
-                                color: textColor
-                              ),
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .headlineMedium
+                                  ?.copyWith(
+                                      fontWeight: FontWeight.bold,
+                                      color: textColor),
                             )
                           ],
                         ),
@@ -431,20 +453,21 @@ class _HomePageState extends State<HomePage> {
                                 Row(
                                   children: [
                                     (status.data == null
-                                        ? -1
-                                        : status.data.index) <=
-                                        Status.loadUserData.index
+                                                ? -1
+                                                : status.data.index) <=
+                                            Status.loadUserData.index
                                         ? const Center(
-                                      child: SizedBox(
-                                        width: 20,
-                                        height: 20,
-                                        child: CircularProgressIndicator(),
-                                      ),
-                                    )
+                                            child: SizedBox(
+                                              width: 20,
+                                              height: 20,
+                                              child:
+                                                  CircularProgressIndicator(),
+                                            ),
+                                          )
                                         : const Icon(
-                                      Icons.check,
-                                      size: 20,
-                                    ),
+                                            Icons.check,
+                                            size: 20,
+                                          ),
                                     Padding(
                                       padding: const EdgeInsets.only(left: 8),
                                       child: Text(
@@ -461,18 +484,22 @@ class _HomePageState extends State<HomePage> {
                                   child: Row(
                                     children: [
                                       (status.data == null
-                                          ? -1
-                                          : status.data.index) <=
-                                          Status.login.index
+                                                  ? -1
+                                                  : status.data.index) <=
+                                              Status.login.index
                                           ? const Center(
-                                        child: SizedBox(
-                                          width: 20,
-                                          height: 20,
-                                          child:
-                                          CircularProgressIndicator(),
-                                        ),
-                                      )
-                                          : status.data == Status.errorLogin ? const Icon(Icons.error, size: 20) : const Icon(Icons.check, size: 20),
+                                              child: SizedBox(
+                                                width: 20,
+                                                height: 20,
+                                                child:
+                                                    CircularProgressIndicator(),
+                                              ),
+                                            )
+                                          : status.data == Status.errorLogin
+                                              ? const Icon(Icons.error,
+                                                  size: 20)
+                                              : const Icon(Icons.check,
+                                                  size: 20),
                                       Padding(
                                         padding: const EdgeInsets.only(left: 8),
                                         child: Text(
@@ -499,21 +526,25 @@ class _HomePageState extends State<HomePage> {
                                           onPressed: () {
                                             Navigator.push(
                                               context,
-                                              MaterialPageRoute(builder: (context) => BugReportScreen(generatedMessage: "AUTOMATISCH GENERIERT:\nLogin Page: ${status.data.message}\n$errorCode: ${client.statusCodes[errorCode]}\n\nMehr Details von dir:\n")),
+                                              MaterialPageRoute(
+                                                  builder: (context) =>
+                                                      BugReportScreen(
+                                                          generatedMessage:
+                                                              "AUTOMATISCH GENERIERT:\nLogin Page: ${status.data.message}\n$errorCode: ${client.statusCodes[errorCode]}\n\nMehr Details von dir:\n")),
                                             ).then((result) {
                                               openFeature(selectedFeature);
                                             });
                                           },
-                                          child: const Text("Fehlerbericht senden")
-                                      ),
+                                          child: const Text(
+                                              "Fehlerbericht senden")),
                                       Padding(
                                         padding: const EdgeInsets.only(left: 8),
                                         child: OutlinedButton(
                                             onPressed: () async {
                                               await performLogin();
                                             },
-                                            child: const Text("Erneut versuchen")
-                                        ),
+                                            child:
+                                                const Text("Erneut versuchen")),
                                       )
                                     ],
                                   ),
@@ -536,7 +567,9 @@ class _HomePageState extends State<HomePage> {
                         Padding(
                           padding: const EdgeInsets.only(
                               left: 12, right: 28.0, bottom: 28.0, top: 28.0),
-                          child: status.data == (Status.errorLogin) ? const Icon(Icons.error, size: 30) : const CircularProgressIndicator(),
+                          child: status.data == (Status.errorLogin)
+                              ? const Icon(Icons.error, size: 30)
+                              : const CircularProgressIndicator(),
                         ),
                       ],
                     ),

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -121,7 +121,6 @@ class _HomePageState extends State<HomePage> {
   // For status messages
   late final StreamController statusController;
   late int errorCode;
-  List<int?> bottomNavbarNavigationTranslation = [];
 
   static List<Widget> featureScreens() {
     return <Widget>[
@@ -138,22 +137,6 @@ class _HomePageState extends State<HomePage> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       performLogin();
     });
-
-    int helpIndex = 0;
-    for (var supported in [
-      client.doesSupportFeature("Vertretungsplan"),
-      client.doesSupportFeature("Kalender"),
-      client.doesSupportFeature("Nachrichten - Beta-Version"),
-      client.doesSupportFeature("Mein Unterricht") ||
-          client.doesSupportFeature("mein Unterricht")
-    ]) {
-      if (supported) {
-        bottomNavbarNavigationTranslation.add(helpIndex);
-        helpIndex += 1;
-      } else {
-        bottomNavbarNavigationTranslation.add(null);
-      }
-    }
 
     super.initState();
   }
@@ -272,11 +255,30 @@ class _HomePageState extends State<HomePage> {
     final Color textColor =
         imageColor.computeLuminance() < 0.5 ? Colors.white : Colors.black;
 
+    List<int?> bottomNavbarNavigationTranslation = [];
+
+    int helpIndex = 0;
+    for (var supported in [
+      client.doesSupportFeature("Vertretungsplan"),
+      client.doesSupportFeature("Kalender"),
+      client.doesSupportFeature("Nachrichten - Beta-Version"),
+      client.doesSupportFeature("Mein Unterricht") ||
+          client.doesSupportFeature("mein Unterricht")
+    ]) {
+      if (supported) {
+        bottomNavbarNavigationTranslation.add(helpIndex);
+        helpIndex += 1;
+      } else {
+        bottomNavbarNavigationTranslation.add(null);
+      }
+    }
+
     return isLoading
         ? loadingScreen()
         : Scaffold(
             appBar: AppBar(
-              title: Text(selectedFeature.value!),
+              title: Text(selectedFeature
+                  .value!), // We could also use a list with all title names, but a empty title should be always the first page (Vp)
             ),
             body: Center(
               child: featureScreens()[selectedFeature.index],

--- a/app/lib/view/mein_unterricht/mein_unterricht.dart
+++ b/app/lib/view/mein_unterricht/mein_unterricht.dart
@@ -9,10 +9,10 @@ class MeinUnterrichtAnsicht extends StatefulWidget {
   State<StatefulWidget> createState() => _MeinUnterrichtAnsichtState();
 }
 
-class _MeinUnterrichtAnsichtState extends State<MeinUnterrichtAnsicht> {
-  final double padding = 10.0;
+class _MeinUnterrichtAnsichtState extends State<MeinUnterrichtAnsicht> with TickerProviderStateMixin {
+  final double padding = 8.0;
+  late TabController _tabController;
 
-  int _currentIndex = 0;
   bool loading = true;
   dynamic data = {"aktuell": [], "anwesenheiten": [], "kursmappen": []};
 
@@ -20,6 +20,13 @@ class _MeinUnterrichtAnsichtState extends State<MeinUnterrichtAnsicht> {
   void initState() {
     super.initState();
     _loadData();
+    _tabController = TabController(length: 3, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
   }
 
   Future<void> _loadData({secondTry= false}) async {
@@ -43,127 +50,6 @@ class _MeinUnterrichtAnsichtState extends State<MeinUnterrichtAnsicht> {
     }
   }
 
-  Widget _buildBody() {
-    switch (_currentIndex) {
-      case 0: // Aktuelle Einträge
-        return ListView.builder(
-          itemCount: data["aktuell"].length,
-          itemBuilder: (BuildContext context, int index) {
-            return Padding(
-                padding: EdgeInsets.only(
-                    left: padding, right: padding, bottom: padding),
-                child: Card(
-                  child: ListTile(
-                    title: Text(data["aktuell"][index]["name"]),
-                    subtitle: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                            "Thema: ${data["aktuell"][index]["thema"]["title"]}"),
-                        //TODO implement "inhalt" and "hausaufgaben"
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Text(
-                                "${data["aktuell"][index]["teacher"]["short"]}-${data["aktuell"][index]["teacher"]["name"]}"),
-                            Text(data["aktuell"][index]["thema"]["date"])
-                          ],
-                        ),
-                      ],
-                    ),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => CourseOverviewAnsicht(
-                                  dataFetchURL: data["aktuell"][index]
-                                      ["_courseURL"],
-                                )),
-                      );
-                    },
-                  ),
-                ));
-          },
-        );
-      case 1: // Kursmappen
-        return ListView.builder(
-          itemCount: data["kursmappen"].length,
-          itemBuilder: (BuildContext context, int index) {
-            return Padding(
-                padding: EdgeInsets.only(
-                    left: padding, right: padding, bottom: padding),
-                child: Card(
-                  child: ListTile(
-                    title: Text(data["kursmappen"][index]["title"]),
-                    subtitle: Text(data["kursmappen"][index]["teacher"]),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => CourseOverviewAnsicht(
-                                  dataFetchURL: data["kursmappen"][index]
-                                      ["_courseURL"],
-                                )),
-                      );
-                    },
-                  ),
-                ));
-          },
-        );
-      case 2: // Anwesenheiten
-        return ListView.builder(
-          itemCount: data["anwesenheiten"].length,
-          itemBuilder: (BuildContext context, int index) {
-            List<String> keysNotRender = ["Kurs", "Lehrkraft", "_courseURL"];
-            List<Widget> rowChildren = [];
-
-            data["anwesenheiten"][index].forEach((key, value) {
-              if (!keysNotRender.contains(key) && value != "") {
-                rowChildren.add(Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [Text("$key:"), Text(value)],
-                ));
-              }
-            });
-
-            return Padding(
-                padding: EdgeInsets.only(
-                    left: padding, right: padding, bottom: padding),
-                child: Card(
-                  child: ListTile(
-                    title: Text(data["anwesenheiten"][index]["Kurs"]),
-                    subtitle: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: rowChildren,
-                    ),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => CourseOverviewAnsicht(
-                                  dataFetchURL: data["anwesenheiten"][index]
-                                      ["_courseURL"],
-                                )),
-                      );
-                    },
-                  ),
-                ));
-          },
-        );
-      default:
-        return const Text('Unknown Content');
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     if (loading) {
@@ -173,34 +59,142 @@ class _MeinUnterrichtAnsichtState extends State<MeinUnterrichtAnsicht> {
     }
 
     return Scaffold(
-      body: _buildBody(),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _loadData,
-        child: const Icon(Icons.refresh),
-      ),
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: _currentIndex,
-        onDestinationSelected: (int index) {
-          setState(() {
-            _currentIndex = index;
-          });
-        },
-        destinations: const [
-          NavigationDestination(
-            icon: Icon(Icons.list),
-            selectedIcon: Icon(Icons.list_outlined),
-            label: 'Aktuelle Einträge',
+      body: Column(
+        children: [
+          TabBar(
+            controller: _tabController,
+              tabs: const [
+                Tab(
+                  icon: Icon(Icons.list),
+                  text: "Aktuelles",
+                ),
+                Tab(
+                  icon: Icon(Icons.folder_copy),
+                  text: "Kursmappen"
+                ),
+                Tab(
+                  icon: Icon(Icons.calendar_today),
+                  text: "Anwesenheiten",
+                )
+              ]
           ),
-          NavigationDestination(
-            icon: Icon(Icons.folder_copy),
-            selectedIcon: Icon(Icons.folder_copy_outlined),
-            label: 'Kursmappen',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.calendar_today),
-            selectedIcon: Icon(Icons.calendar_today_outlined),
-            label: 'Anwesenheiten',
-          ),
+          Expanded(
+              child: TabBarView(
+                controller: _tabController,
+                children: [
+                  ListView.builder(
+                    itemCount: data["aktuell"].length,
+                    itemBuilder: (BuildContext context, int index) {
+                      return Padding(
+                          padding: EdgeInsets.only(
+                              left: padding, right: padding, bottom: padding),
+                          child: Card(
+                            child: ListTile(
+                              title: Text(data["aktuell"][index]["name"]),
+                              subtitle: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                      "Thema: ${data["aktuell"][index]["thema"]["title"]}"),
+                                  Row(
+                                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                    children: [
+                                      Text(
+                                          "${data["aktuell"][index]["teacher"]["short"]}-${data["aktuell"][index]["teacher"]["name"]}"),
+                                      Text(data["aktuell"][index]["thema"]["date"])
+                                    ],
+                                  ),
+                                ],
+                              ),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              onTap: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (context) => CourseOverviewAnsicht(
+                                        dataFetchURL: data["aktuell"][index]
+                                        ["_courseURL"],
+                                      )),
+                                );
+                              },
+                            ),
+                          ));
+                    },
+                  ),
+                  ListView.builder(
+                    itemCount: data["kursmappen"].length,
+                    itemBuilder: (BuildContext context, int index) {
+                      return Padding(
+                          padding: EdgeInsets.only(
+                              left: padding, right: padding, bottom: padding),
+                          child: Card(
+                            child: ListTile(
+                              title: Text(data["kursmappen"][index]["title"]),
+                              subtitle: Text(data["kursmappen"][index]["teacher"]),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              onTap: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (context) => CourseOverviewAnsicht(
+                                        dataFetchURL: data["kursmappen"][index]
+                                        ["_courseURL"],
+                                      )),
+                                );
+                              },
+                            ),
+                          ));
+                    },
+                  ),
+                  ListView.builder(
+                    itemCount: data["anwesenheiten"].length,
+                    itemBuilder: (BuildContext context, int index) {
+                      List<String> keysNotRender = ["Kurs", "Lehrkraft", "_courseURL"];
+                      List<Widget> rowChildren = [];
+
+                      data["anwesenheiten"][index].forEach((key, value) {
+                        if (!keysNotRender.contains(key) && value != "") {
+                          rowChildren.add(Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [Text("$key:"), Text(value)],
+                          ));
+                        }
+                      });
+
+                      return Padding(
+                          padding: EdgeInsets.only(
+                              left: padding, right: padding, bottom: padding),
+                          child: Card(
+                            child: ListTile(
+                              title: Text(data["anwesenheiten"][index]["Kurs"]),
+                              subtitle: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: rowChildren,
+                              ),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              onTap: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (context) => CourseOverviewAnsicht(
+                                        dataFetchURL: data["anwesenheiten"][index]
+                                        ["_courseURL"],
+                                      )),
+                                );
+                              },
+                            ),
+                          ));
+                    },
+                  )
+                ],
+              )
+          )
         ],
       ),
     );


### PR DESCRIPTION
Es ist jetzt so, dass es standartmäßig die vier einträge
 - vertretungsplan
 - kalender
 - nachrichten
 - mein unterricht
gibt. Was nicht unterstützt wird, wird aus der Navigationbar konmplett gestrichen. 

Die Navigationbar in "Mein Unterricht" (main page) wurde durch eine TabView ausgetauscht.